### PR TITLE
Dev/cnc set origin - Closing issue #10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,161 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+

--- a/docs/api_cnc.rst
+++ b/docs/api_cnc.rst
@@ -14,3 +14,11 @@ pystages.cncrouter
 .. autoclass:: GRBLSetting
     :members:
     :undoc-members:
+
+.. autoclass:: InvertMask
+    :members:
+    :undoc-members:
+
+.. autoclass:: StatusReportMask
+    :members:
+    :undoc-members:

--- a/docs/api_cnc.rst
+++ b/docs/api_cnc.rst
@@ -10,3 +10,7 @@ pystages.cncrouter
 .. autoclass:: CNCStatus
     :members:
     :undoc-members:
+
+.. autoclass:: GRBLSetting
+    :members:
+    :undoc-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,6 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = []
 
 html_logo = "logo.png"

--- a/pystages/cncrouter.py
+++ b/pystages/cncrouter.py
@@ -50,9 +50,9 @@ class CNCRouter(Stage):
         Open serial device to connect to the CNC routers. Raise a
         ConnectionFailure exception if the serial device could not be open.
 
-        :param dev: Serial device. For instance '/dev/ttyUSB0'.
+        :param dev: Serial device. For instance `'/dev/ttyUSB0'`.
         :param reset_wait_time: Depending on the state of the stage, it can take some time for
-        GRBL to reset. This parameter makes the wait time to be tuned, by giving a time in seconds.
+         GRBL to reset. This parameter makes the wait time to be tuned, by giving a time in seconds.
         """
         super().__init__(num_axis=3)
         self.reset_wait_time = reset_wait_time
@@ -65,9 +65,10 @@ class CNCRouter(Stage):
     def reset_grbl(self, wait_time: Optional[float] = None) -> bool:
         """
         Sends a CTRL+X control to reset the GRBL
+
         :return: True if the GRBL sends the correct prompt
         :param wait_time: Depending on the state of the stage, it can take some time for GRBL to
-        reset. This parameter makes the wait time to be tuned, by giving a time in seconds.
+         reset. This parameter makes the wait time to be tuned, by giving a time in seconds.
         """
         if wait_time is None:
             wait_time = self.reset_wait_time
@@ -88,7 +89,7 @@ class CNCRouter(Stage):
 
     def sleep(self):
         """
-        Sends a $SLP command. The stage responds a message '[MSG:Sleeping]' after 'ok'.
+        Sends a `$SLP` command. The stage responds a message `[MSG:Sleeping]` after `ok`.
         """
         self.send_receive("$SLP")
         return self.receive()
@@ -96,15 +97,17 @@ class CNCRouter(Stage):
     def unlock(self) -> bool:
         """
         Unlock the motor. It may happen when the stage has gone further its limits,
-        and raised an alarm, or has been disabled when going in sleep mode ('$SLP')
-        :return: True if message [MSG:Caution: Unlock] has been returned
+        and raised an alarm, or has been disabled when going in sleep mode (`$SLP`)
+
+        :return: `True` if message `[MSG:Caution: Unlock]` has been returned
         """
         self.send("$X")
         return "[MSG:Caution: Unlocked]" in self.receive_lines()
 
     def get_grbl_settings(self) -> dict:
         """
-        Obtains and parse the list of GRBLSettings with the '$$' command.
+        Obtains and parse the list of GRBLSettings with the `$$` command.
+
         :return: A dictionary containing the GRBLSetting as key and its corresponding value
         """
         self.send("$$")
@@ -124,8 +127,9 @@ class CNCRouter(Stage):
         """
         Sending '?' character permits to get the status of the CNC
         router
-        :return: A tuple containing the status and a dictionary of all other
-        parameters in the output of the command.
+
+        :return: A tuple containing the status and a dictionary of all other parameters in the
+         output of the command.
         """
         self.send("?", eol="")
         status = self.receive()
@@ -163,10 +167,11 @@ class CNCRouter(Stage):
 
     def receive_lines(self, until: str = "ok") -> List[str]:
         """
-        Receive multiple lines until getting as specific value
+        Receive multiple lines until getting as specific value.
+
         :param until: The expected response indicating the end of received lines.
         :return: The list of all received lines. Note that the expected line is not included in the
-        list.
+         list.
         """
         lines = []
         while (l := self.serial.readline().strip().decode()) != until:

--- a/pystages/cncrouter.py
+++ b/pystages/cncrouter.py
@@ -244,7 +244,10 @@ class CNCRouter(Stage):
         :setter: Move the stage.
         """
         res = self.get_current_status()[1]["MPos"]
-        return Vector(*tuple(float(x) for x in res))
+        mpos = Vector(*tuple(float(x) for x in res))
+        res = self.get_current_status()[1]["WCO"]
+        wco = Vector(*tuple(float(x) for x in res))
+        return mpos - wco
 
     @position.setter
     def position(self, value: Vector):

--- a/pystages/cncrouter.py
+++ b/pystages/cncrouter.py
@@ -66,7 +66,7 @@ class CNCRouter(Stage):
         """
         Sends a CTRL+X control to reset the GRBL
 
-        :return: True if the GRBL sends the correct prompt
+        :return: True if the GRBL sent the correct prompt at the end of the reset
         :param wait_time: Depending on the state of the stage, it can take some time for GRBL to
          reset. This parameter makes the wait time to be tuned, by giving a time in seconds.
         """
@@ -92,9 +92,11 @@ class CNCRouter(Stage):
         )
         return ok
 
-    def sleep(self):
+    def sleep(self) -> str:
         """
         Sends a `$SLP` command. The stage responds a message `[MSG:Sleeping]` after `ok`.
+
+        :return: The response of the CNC ('ok' if command has been submitted correctly).
         """
         self.send_receive("$SLP")
         return self.receive()
@@ -263,7 +265,12 @@ class CNCRouter(Stage):
 
     @property
     def is_moving(self) -> bool:
-        """Queries the current status of the CNC in order to determine if the CNC is moving"""
+        """
+        Queries the current status of the CNC in order to determine if the CNC is moving
+
+        :return: True if the CNC reports that a cycle is running (Run) or
+         if it is in a middle of a homing cycle.
+        """
         status = self.get_current_status()[0]
         return status in [CNCStatus.RUN, CNCStatus.HOME]
 

--- a/pystages/cncrouter.py
+++ b/pystages/cncrouter.py
@@ -274,9 +274,10 @@ class CNCRouter(Stage):
         status = self.get_current_status()[0]
         return status in [CNCStatus.RUN, CNCStatus.HOME]
 
-    def set_origin(self):
+    def set_origin(self) -> str:
         """
         Set current position as origin
-        :return:
+
+        :return: The response of the CNC ('ok' if command has been submitted correctly).
         """
         return self.send_receive("G92 X0 Y0 Z0")

--- a/pystages/cncrouter.py
+++ b/pystages/cncrouter.py
@@ -134,7 +134,7 @@ class CNCRouter(Stage):
             # Get the int value of the boolean (1 if true, 0 if false)
             value = 1 if value else 0
         # We do nothing for int and floats.
-        return self.send_receive(f"${setting.value}={value}")
+        return self.send_receive(f"{setting.value}={value}")
 
     def get_grbl_settings(self) -> dict:
         """

--- a/pystages/cncrouter.py
+++ b/pystages/cncrouter.py
@@ -85,6 +85,11 @@ class CNCRouter(Stage):
         # Unlock if necessary
         if "[MSG:'$H'|'$X' to unlock]" in responses:
             ok = self.unlock()
+        # Force status report to send Machine Position and Work Position
+        self.set_grbl_setting(
+            GRBLSetting.STATUS_REPORT_MASK,
+            StatusReportMask.MACHINE_POSITION | StatusReportMask.WORK_POSITION,
+        )
         return ok
 
     def sleep(self):

--- a/pystages/cncrouter.py
+++ b/pystages/cncrouter.py
@@ -245,10 +245,11 @@ class CNCRouter(Stage):
         :getter: Query and return stage position.
         :setter: Move the stage.
         """
-        res = self.get_current_status()[1]["MPos"]
-        mpos = Vector(*tuple(float(x) for x in res))
-        res = self.get_current_status()[1]["WCO"]
-        wco = Vector(*tuple(float(x) for x in res))
+        status = {}
+        while "WCO" not in status:
+            status = self.get_current_status()[1]
+        mpos = Vector(*tuple(float(x) for x in status["MPos"]))
+        wco = Vector(*tuple(float(x) for x in status["WCO"]))
         return mpos - wco
 
     @position.setter

--- a/pystages/smc100.py
+++ b/pystages/smc100.py
@@ -423,7 +423,7 @@ class SMC100(Stage):
         DISABLE state makes the motor not energized and opens the control loop.
 
         :param addr: address of the axis to operate.
-        If None is passed, it applies to all controllers
+         If None is passed, it applies to all controllers
         :param enter: True to enter, False to leave DISABLE state
         """
         # MM0 changes the controller’s state from READY to DISABLE (enter)

--- a/pystages/stage.py
+++ b/pystages/stage.py
@@ -30,7 +30,7 @@ class Stage(ABC):
     def __init__(self, num_axis=1):
         """
         :param num_axis: The number of axis of the stage, can be updated or set after initialisation
-        of the object.
+         of the object.
         """
         self.num_axis = num_axis
         # The wait routine is a function that is called when the wait_move_finished is looping.

--- a/pystages/tic.py
+++ b/pystages/tic.py
@@ -115,11 +115,10 @@ class TicDirection(Enum):
 
 class Tic(Stage):
     """
-    Very basic driver class for Polulu Tic Stepper Motor controller, connected
-    in USB.
+    Very basic driver class for Polulu Tic Stepper Motor controller, connected in USB.
 
     :ivar poll_interval: Interval between successive state polling for some
-        long motor operations.
+     long motor operations.
     """
 
     def __init__(self):

--- a/pystages/vector.py
+++ b/pystages/vector.py
@@ -33,7 +33,7 @@ class Vector:
         """
         if dim is not None:
             if len(args) > dim:
-                raise ValueError("Two many initial values for this dimension.")
+                raise ValueError("Too many initial values for this dimension.")
             self.data = list(args)
             while len(self.data) < dim:
                 self.data.append(0)


### PR DESCRIPTION
This PR closes the issue #10: when setting the origin a commands makes the 'WCO' to be set to current machine position and sticks to this value. However the Machine position is not 'offseted'. The 'Get position' must then take into account the value of WCO in 'get_current_status'.

Note that:
- WCO is not systematically given (it is after several sendings of get_status ('?') command)
- The CNC can be configured to send it systematically according to the documentation. Configuration is done at startup (see commit 7739055df14505b623e8c52e7c414bec493acbe6) but does not seems to make any effect.
