### PR TITLE
Fix CNCStatus parsing

### DIFF
--- a/pystages/cncrouter.py
+++ b/pystages/cncrouter.py
@@ -269,8 +269,15 @@ class CNCRouter(Stage):
         # Remove the chevrons and split all pipes.
         elements = status[1:-1].split("|")
 
-        # First element is the CNC status
-        cncstatus = CNCStatus(elements[0])
+        # First element is the CNC status. Some GRBL firmware variants append
+        # a sub-state with a comma, while standard GRBL uses a colon.
+        raw_status = elements[0]
+        normalized_status = raw_status.split(":", 1)[0].split(",", 1)[0]
+        if normalized_status != raw_status:
+            self.logger.debug(
+                "Normalizing CNC status %r to %r", raw_status, normalized_status
+            )
+        cncstatus = CNCStatus(normalized_status)
 
         # Next elements to be parsed as key/value pairs
         others: dict[str, object] = {}

--- a/tests/test_cnc_status.py
+++ b/tests/test_cnc_status.py
@@ -1,0 +1,62 @@
+import logging
+
+import pytest
+
+from pystages.cncrouter import CNCRouter, CNCStatus
+from pystages.stage import Stage
+
+
+def make_router_with_status(
+    monkeypatch: pytest.MonkeyPatch, response: str
+) -> CNCRouter:
+    router = CNCRouter.__new__(CNCRouter)
+    Stage.__init__(router, num_axis=3)
+    monkeypatch.setattr(router, "send", lambda *args, **kwargs: None)
+    monkeypatch.setattr(router, "receive", lambda: response)
+    return router
+
+
+@pytest.mark.parametrize(
+    ("raw_status", "expected_status"),
+    [("Run,0", CNCStatus.RUN), ("Hold:0", CNCStatus.HOLD)],
+)
+def test_get_current_status_normalizes_substate(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    raw_status: str,
+    expected_status: CNCStatus,
+):
+    router = make_router_with_status(
+        monkeypatch,
+        f"<{raw_status}|MPos:1.000,2.000,3.000|WCO:0.000,0.000,0.000>",
+    )
+    caplog.set_level(logging.DEBUG, logger="CNCRouter")
+
+    result = router.get_current_status()
+
+    assert result == (
+        expected_status,
+        {
+            "MPos": ["1.000", "2.000", "3.000"],
+            "WCO": ["0.000", "0.000", "0.000"],
+        },
+    )
+    assert (
+        f"Normalizing CNC status '{raw_status}' to '{expected_status.value}'"
+        in caplog.messages
+    )
+
+
+def test_get_current_status_keeps_unsuffixed_status(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    router = make_router_with_status(monkeypatch, "<Idle|MPos:1.000,2.000,3.000>")
+    caplog.set_level(logging.DEBUG, logger="CNCRouter")
+
+    result = router.get_current_status()
+
+    assert result == (
+        CNCStatus.IDLE,
+        {"MPos": ["1.000", "2.000", "3.000"]},
+    )
+    assert not caplog.messages


### PR DESCRIPTION
- Normalize CNC statuses such as Run,0 and Hold:0.
- Add debug logging when normalization occurs.
- Add regression tests covering suffixed and standard statuses.